### PR TITLE
auto-scaler types

### DIFF
--- a/pkg/api/register.go
+++ b/pkg/api/register.go
@@ -55,6 +55,8 @@ func init() {
 		&NamespaceList{},
 		&Secret{},
 		&SecretList{},
+		&AutoScaler{},
+		&AutoScalerList{},
 	)
 	// Legacy names are supported
 	Scheme.AddKnownTypeWithName("", "Minion", &Node{})
@@ -91,3 +93,5 @@ func (*Namespace) IsAnAPIObject()                 {}
 func (*NamespaceList) IsAnAPIObject()             {}
 func (*Secret) IsAnAPIObject()                    {}
 func (*SecretList) IsAnAPIObject()                {}
+func (*AutoScaler) IsAnAPIObject()                {}
+func (*AutoScalerList) IsAnAPIObject()            {}

--- a/pkg/api/rest/types.go
+++ b/pkg/api/rest/types.go
@@ -162,3 +162,30 @@ func (namespaceStrategy) Validate(obj runtime.Object) errors.ValidationErrorList
 	namespace := obj.(*api.Namespace)
 	return validation.ValidateNamespace(namespace)
 }
+
+// autoScalerStrategy implements behavior for AutoScalers
+type autoScalerStrategy struct {
+	runtime.ObjectTyper
+	api.NameGenerator
+}
+
+// AutoScalers is the default logic that applies when creating and updating AutoScalers
+// objects.
+var AutoScalers RESTCreateStrategy = autoScalerStrategy{api.Scheme, api.SimpleNameGenerator}
+
+// NamespaceScoped is true for AutoScalers.
+func (autoScalerStrategy) NamespaceScoped() bool {
+	return true
+}
+
+// ResetBeforeCreate clears fields that are not allowed to be set by end users on creation.
+func (autoScalerStrategy) ResetBeforeCreate(obj runtime.Object) {
+	autoScaler := obj.(*api.AutoScaler)
+	autoScaler.Status = api.AutoScalerStatus{}
+}
+
+// Validate validates a new AutoScalers.
+func (autoScalerStrategy) Validate(obj runtime.Object) errors.ValidationErrorList {
+	autoScaler := obj.(*api.AutoScaler)
+	return validation.ValidateAutoScaler(autoScaler)
+}

--- a/pkg/api/testing/fuzzer.go
+++ b/pkg/api/testing/fuzzer.go
@@ -219,6 +219,11 @@ func FuzzerFor(t *testing.T, version string, src rand.Source) *fuzz.Fuzzer {
 				ss.ContainerPort.StrVal = "x" + ss.ContainerPort.StrVal // non-empty
 			}
 		},
+		func(a *api.AutoScaler, c fuzz.Continue) {
+			c.Fuzz(&a.TypeMeta)
+			c.Fuzz(&a.ObjectMeta)
+			c.Fuzz(&a.Spec)
+		},
 	)
 	return f
 }

--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -1456,3 +1456,94 @@ func AddToNodeAddresses(addresses *[]NodeAddress, addAddresses ...NodeAddress) {
 		}
 	}
 }
+
+// AutoScaler monitors other resources that are resizeable and adjusts them according to configuration.
+type AutoScaler struct {
+	TypeMeta   `json:",inline"`
+	ObjectMeta `json:"metadata,omitempty"`
+
+	// Spec defines the auto-scaler targets and thresholds.
+	Spec AutoScalerSpec `json:"spec,omitempty"`
+
+	// Status defines the actions the auto-scaler has taken.
+	Status AutoScalerStatus `json:"status,omitempty"`
+}
+
+// AutoScalerStatus provides the status of an auto-scaler.
+type AutoScalerStatus struct {
+	// TODO: open for discussion on what meaningful information can be reported in the status
+	// The status may return the replica count here but we may want more information
+	// such as if the count reflects a threshold being passed.
+}
+
+// AutoScalerSpec defines the auto-scaler targets and thresholds.
+type AutoScalerSpec struct {
+	// Thresholds holds a collection of AutoScaleThresholds that drive the auto-scaler.
+	Thresholds []AutoScaleThreshold `json:"thresholds,omitempty"`
+
+	// Enabled turns auto scaling on or off.
+	Enabled bool `json:"enabled,omitempty"`
+
+	// MaxAutoScaleCount defines the max replicas that the auto-scaler can use.  This value must be
+	// >= MinAutoScaleCount.
+	MaxAutoScaleCount int `json:"maxAutoScaleCount,omitempty"`
+
+	// MinAutoScaleCount defines the minimum number replicas that the auto-scaler can reduce to,
+	// 0 means that the application is allowed to idle.
+	MinAutoScaleCount int `json:"minAutoScaleCount,omitempty"`
+
+	// TargetSelector provides the resizeable target(s).  Right now this is a ReplicationController
+	// in the future it could be a job or any resource that implements resize.  If multiple targets
+	// are resolved by the selector the auto-scaler will resize the largest one.
+	TargetSelector map[string]string `json:"targetSelector,omitempty"`
+
+	// MonitorSelector defines a set of capacity that the auto-scaler is monitoring
+	// (replication controllers).  Monitored objects are used by thresholds to examine
+	// statistics.  Example: get statistic X for object Y to see if threshold is passed.
+	MonitorSelector map[string]string `json:"monitorSelector,omitempty"`
+}
+
+// AutoScaleThreshold is a behavior based on statistics used to drive the auto-scaler in scaling decisions.
+type AutoScaleThreshold struct {
+	// Type is the type of threshold being used, intention or value.
+	Type AutoScaleThresholdType `json:"type,omitempty"`
+
+	// IntentionConfig holds the config for intention based thresholds.
+	IntentionConfig AutoScaleIntentionThresholdConfig `json:"intentionConfig,omitempty"`
+}
+
+// AutoScaleIntentionThresholdConfig holds configuration for intention based thresholds.
+// The scaler will adjust by 1 accordingly and maintain once the intention is reached.
+type AutoScaleIntentionThresholdConfig struct {
+	// Intent is the lexicon of what intention is requested.
+	Intent AutoScaleIntentionType `json:"intent,omitempty"`
+
+	// Value is intention dependent in terms of above, below, equal and represents
+	// the value to check against.
+	Value float32 `json:"value,omitempty"`
+}
+
+// AutoScaleThresholdType is either intention based or value based.
+type AutoScaleThresholdType string
+
+// AutoScaleIntentionType is a lexicon for intentions such as "cpu-utilization",
+// "max-rps-per-endpoint".
+type AutoScaleIntentionType string
+
+// Constants for auto-scalers and any auto-scaling child types like intentions
+const (
+	// AutoScaleThresholdTypeIntention is used when defining an intention based threshold.
+	AutoScaleThresholdTypeIntention AutoScaleThresholdType = "Intention"
+
+	// TODO: AutoScaleIntentionType types
+	// example: AutoScaleIntentionTypeMaxRPS AutoScaleIntentionType = "MaxRPS"
+)
+
+// AutoScalerList is a list of AutoScaler items
+type AutoScalerList struct {
+	TypeMeta `json:",inline"`
+	ListMeta `json:"metadata,omitempty"`
+
+	// Items is a list of AutoScaler objects.
+	Items []AutoScaler `json:"items"`
+}

--- a/pkg/api/v1beta1/conversion.go
+++ b/pkg/api/v1beta1/conversion.go
@@ -1371,6 +1371,36 @@ func init() {
 			out.PodID = in.Name
 			return nil
 		},
+		func(in *newer.AutoScalerList, out *AutoScalerList, s conversion.Scope) error {
+			if err := s.Convert(&in.TypeMeta, &out.TypeMeta, 0); err != nil {
+				return err
+			}
+			if err := s.Convert(&in.ListMeta, &out.TypeMeta, 0); err != nil {
+				return err
+			}
+			if err := s.Convert(&in.Items, &out.Items, 0); err != nil {
+				return err
+			}
+			return nil
+		},
+		func(in *newer.AutoScaler, out *AutoScaler, s conversion.Scope) error {
+			if err := s.Convert(&in.TypeMeta, &out.TypeMeta, 0); err != nil {
+				return err
+			}
+			if err := s.Convert(&in.ObjectMeta, &out.TypeMeta, 0); err != nil {
+				return err
+			}
+
+			if err := s.Convert(&in.Spec, &out.Spec, 0); err != nil {
+				return err
+			}
+
+			if err := s.Convert(&in.Status, &out.Status, 0); err != nil {
+				return err
+			}
+
+			return nil
+		},
 	)
 	if err != nil {
 		// If one of the conversion functions is malformed, detect it immediately.

--- a/pkg/api/v1beta1/register.go
+++ b/pkg/api/v1beta1/register.go
@@ -62,6 +62,8 @@ func init() {
 		&NamespaceList{},
 		&Secret{},
 		&SecretList{},
+		&AutoScaler{},
+		&AutoScalerList{},
 	)
 	// Future names are supported
 	api.Scheme.AddKnownTypeWithName("v1beta1", "Node", &Minion{})
@@ -98,3 +100,5 @@ func (*Namespace) IsAnAPIObject()                 {}
 func (*NamespaceList) IsAnAPIObject()             {}
 func (*Secret) IsAnAPIObject()                    {}
 func (*SecretList) IsAnAPIObject()                {}
+func (*AutoScaler) IsAnAPIObject()                {}
+func (*AutoScalerList) IsAnAPIObject()            {}

--- a/pkg/api/v1beta1/types.go
+++ b/pkg/api/v1beta1/types.go
@@ -1195,3 +1195,92 @@ type SecretList struct {
 
 	Items []Secret `json:"items" description:"items is a list of secret objects"`
 }
+
+// AutoScaler monitors other resources that are resizeable and adjusts them according to configuration.
+type AutoScaler struct {
+	TypeMeta `json:",inline"`
+
+	// Spec defines the auto-scaler targets and thresholds.
+	Spec AutoScalerSpec `json:"spec,omitempty"`
+
+	// Status defines the actions the auto-scaler has taken.
+	Status AutoScalerStatus `json:"status,omitempty"`
+}
+
+// AutoScalerStatus provides the status of an auto-scaler.
+type AutoScalerStatus struct {
+	// TODO: open for discussion on what meaningful information can be reported in the status
+	// The status may return the replica count here but we may want more information
+	// such as if the count reflects a threshold being passed.
+}
+
+// AutoScalerSpec defines the auto-scaler targets and thresholds.
+type AutoScalerSpec struct {
+	// Thresholds holds a collection of AutoScaleThresholds that drive the auto-scaler.
+	Thresholds []AutoScaleThreshold `json:"thresholds,omitempty"`
+
+	// Enabled turns auto scaling on or off.
+	Enabled bool `json:"enabled,omitempty"`
+
+	// MaxAutoScaleCount defines the max replicas that the auto-scaler can use.  This value must be
+	// >= MinAutoScaleCount.
+	MaxAutoScaleCount int `json:"maxAutoScaleCount,omitempty"`
+
+	// MinAutoScaleCount defines the minimum number replicas that the auto-scaler can reduce to,
+	// 0 means that the application is allowed to idle.
+	MinAutoScaleCount int `json:"minAutoScaleCount,omitempty"`
+
+	// TargetSelector provides the resizeable target(s).  Right now this is a ReplicationController
+	// in the future it could be a job or any resource that implements resize.  If multiple targets
+	// are resolved by the selector the auto-scaler will resize the largest one.
+	TargetSelector map[string]string `json:"targetSelector,omitempty"`
+
+	// MonitorSelector defines a set of capacity that the auto-scaler is monitoring
+	// (replication controllers).  Monitored objects are used by thresholds to examine
+	// statistics.  Example: get statistic X for object Y to see if threshold is passed.
+	MonitorSelector map[string]string `json:"monitorSelector,omitempty"`
+}
+
+// AutoScaleThreshold is a behavior based on statistics used to drive the auto-scaler in scaling decisions.
+type AutoScaleThreshold struct {
+	// Type is the type of threshold being used, intention or value.
+	Type AutoScaleThresholdType `json:"type,omitempty"`
+
+	// IntentionConfig holds the config for intention based thresholds.
+	IntentionConfig AutoScaleIntentionThresholdConfig `json:"intentionConfig,omitempty"`
+}
+
+// AutoScaleIntentionThresholdConfig holds configuration for intention based thresholds.
+// The scaler will adjust by 1 accordingly and maintain once the intention is reached.
+type AutoScaleIntentionThresholdConfig struct {
+	// Intent is the lexicon of what intention is requested.
+	Intent AutoScaleIntentionType `json:"intent,omitempty"`
+
+	// Value is intention dependent in terms of above, below, equal and represents
+	// the value to check against.
+	Value float32 `json:"value,omitempty"`
+}
+
+// AutoScaleThresholdType is either intention based or value based.
+type AutoScaleThresholdType string
+
+// AutoScaleIntentionType is a lexicon for intentions such as "cpu-utilization",
+// "max-rps-per-endpoint".
+type AutoScaleIntentionType string
+
+// Constants for auto-scalers and any auto-scaling child types like intentions
+const (
+	// AutoScaleThresholdTypeIntention is used when defining an intention based threshold.
+	AutoScaleThresholdTypeIntention AutoScaleThresholdType = "Intention"
+
+	// TODO: AutoScaleIntentionType types
+	// example: AutoScaleIntentionTypeMaxRPS AutoScaleIntentionType = "MaxRPS"
+)
+
+// AutoScalerList is a list of AutoScaler items
+type AutoScalerList struct {
+	TypeMeta `json:",inline"`
+
+	// Items is a list of AutoScaler objects.
+	Items []AutoScaler `json:"items"`
+}

--- a/pkg/api/v1beta2/conversion.go
+++ b/pkg/api/v1beta2/conversion.go
@@ -1287,6 +1287,36 @@ func init() {
 			out.PodID = in.Name
 			return nil
 		},
+		func(in *newer.AutoScalerList, out *AutoScalerList, s conversion.Scope) error {
+			if err := s.Convert(&in.TypeMeta, &out.TypeMeta, 0); err != nil {
+				return err
+			}
+			if err := s.Convert(&in.ListMeta, &out.TypeMeta, 0); err != nil {
+				return err
+			}
+			if err := s.Convert(&in.Items, &out.Items, 0); err != nil {
+				return err
+			}
+			return nil
+		},
+		func(in *newer.AutoScaler, out *AutoScaler, s conversion.Scope) error {
+			if err := s.Convert(&in.TypeMeta, &out.TypeMeta, 0); err != nil {
+				return err
+			}
+			if err := s.Convert(&in.ObjectMeta, &out.TypeMeta, 0); err != nil {
+				return err
+			}
+
+			if err := s.Convert(&in.Spec, &out.Spec, 0); err != nil {
+				return err
+			}
+
+			if err := s.Convert(&in.Status, &out.Status, 0); err != nil {
+				return err
+			}
+
+			return nil
+		},
 	)
 	if err != nil {
 		// If one of the conversion functions is malformed, detect it immediately.

--- a/pkg/api/v1beta2/register.go
+++ b/pkg/api/v1beta2/register.go
@@ -62,6 +62,8 @@ func init() {
 		&NamespaceList{},
 		&Secret{},
 		&SecretList{},
+		&AutoScaler{},
+		&AutoScalerList{},
 	)
 	// Future names are supported
 	api.Scheme.AddKnownTypeWithName("v1beta2", "Node", &Minion{})
@@ -98,3 +100,5 @@ func (*Namespace) IsAnAPIObject()                 {}
 func (*NamespaceList) IsAnAPIObject()             {}
 func (*Secret) IsAnAPIObject()                    {}
 func (*SecretList) IsAnAPIObject()                {}
+func (*AutoScaler) IsAnAPIObject()                {}
+func (*AutoScalerList) IsAnAPIObject()            {}

--- a/pkg/api/v1beta2/types.go
+++ b/pkg/api/v1beta2/types.go
@@ -1259,3 +1259,92 @@ type SecretList struct {
 
 	Items []Secret `json:"items" description:"items is a list of secret objects"`
 }
+
+// AutoScaler monitors other resources that are resizeable and adjusts them according to configuration.
+type AutoScaler struct {
+	TypeMeta `json:",inline"`
+
+	// Spec defines the auto-scaler targets and thresholds.
+	Spec AutoScalerSpec `json:"spec,omitempty"`
+
+	// Status defines the actions the auto-scaler has taken.
+	Status AutoScalerStatus `json:"status,omitempty"`
+}
+
+// AutoScalerStatus provides the status of an auto-scaler.
+type AutoScalerStatus struct {
+	// TODO: open for discussion on what meaningful information can be reported in the status
+	// The status may return the replica count here but we may want more information
+	// such as if the count reflects a threshold being passed.
+}
+
+// AutoScalerSpec defines the auto-scaler targets and thresholds.
+type AutoScalerSpec struct {
+	// Thresholds holds a collection of AutoScaleThresholds that drive the auto-scaler.
+	Thresholds []AutoScaleThreshold `json:"thresholds,omitempty"`
+
+	// Enabled turns auto scaling on or off.
+	Enabled bool `json:"enabled,omitempty"`
+
+	// MaxAutoScaleCount defines the max replicas that the auto-scaler can use.  This value must be
+	// >= MinAutoScaleCount.
+	MaxAutoScaleCount int `json:"maxAutoScaleCount,omitempty"`
+
+	// MinAutoScaleCount defines the minimum number replicas that the auto-scaler can reduce to,
+	// 0 means that the application is allowed to idle.
+	MinAutoScaleCount int `json:"minAutoScaleCount,omitempty"`
+
+	// TargetSelector provides the resizeable target(s).  Right now this is a ReplicationController
+	// in the future it could be a job or any resource that implements resize.  If multiple targets
+	// are resolved by the selector the auto-scaler will resize the largest one.
+	TargetSelector map[string]string `json:"targetSelector,omitempty"`
+
+	// MonitorSelector defines a set of capacity that the auto-scaler is monitoring
+	// (replication controllers).  Monitored objects are used by thresholds to examine
+	// statistics.  Example: get statistic X for object Y to see if threshold is passed.
+	MonitorSelector map[string]string `json:"monitorSelector,omitempty"`
+}
+
+// AutoScaleThreshold is a behavior based on statistics used to drive the auto-scaler in scaling decisions.
+type AutoScaleThreshold struct {
+	// Type is the type of threshold being used, intention or value.
+	Type AutoScaleThresholdType `json:"type,omitempty"`
+
+	// IntentionConfig holds the config for intention based thresholds.
+	IntentionConfig AutoScaleIntentionThresholdConfig `json:"intentionConfig,omitempty"`
+}
+
+// AutoScaleIntentionThresholdConfig holds configuration for intention based thresholds.
+// The scaler will adjust by 1 accordingly and maintain once the intention is reached.
+type AutoScaleIntentionThresholdConfig struct {
+	// Intent is the lexicon of what intention is requested.
+	Intent AutoScaleIntentionType `json:"intent,omitempty"`
+
+	// Value is intention dependent in terms of above, below, equal and represents
+	// the value to check against.
+	Value float32 `json:"value,omitempty"`
+}
+
+// AutoScaleThresholdType is either intention based or value based.
+type AutoScaleThresholdType string
+
+// AutoScaleIntentionType is a lexicon for intentions such as "cpu-utilization",
+// "max-rps-per-endpoint".
+type AutoScaleIntentionType string
+
+// Constants for auto-scalers and any auto-scaling child types like intentions
+const (
+	// AutoScaleThresholdTypeIntention is used when defining an intention based threshold.
+	AutoScaleThresholdTypeIntention AutoScaleThresholdType = "Intention"
+
+	// TODO: AutoScaleIntentionType types
+	// example: AutoScaleIntentionTypeMaxRPS AutoScaleIntentionType = "MaxRPS"
+)
+
+// AutoScalerList is a list of AutoScaler items
+type AutoScalerList struct {
+	TypeMeta `json:",inline"`
+
+	// Items is a list of AutoScaler objects.
+	Items []AutoScaler `json:"items"`
+}

--- a/pkg/api/v1beta3/register.go
+++ b/pkg/api/v1beta3/register.go
@@ -56,6 +56,8 @@ func init() {
 		&NamespaceList{},
 		&Secret{},
 		&SecretList{},
+		&AutoScaler{},
+		&AutoScalerList{},
 	)
 	// Legacy names are supported
 	api.Scheme.AddKnownTypeWithName("v1beta3", "Minion", &Node{})
@@ -92,3 +94,5 @@ func (*Namespace) IsAnAPIObject()                 {}
 func (*NamespaceList) IsAnAPIObject()             {}
 func (*Secret) IsAnAPIObject()                    {}
 func (*SecretList) IsAnAPIObject()                {}
+func (*AutoScaler) IsAnAPIObject()                {}
+func (*AutoScalerList) IsAnAPIObject()            {}

--- a/pkg/api/v1beta3/types.go
+++ b/pkg/api/v1beta3/types.go
@@ -1340,3 +1340,94 @@ type SecretList struct {
 
 	Items []Secret `json:"items" description:"items is a list of secret objects"`
 }
+
+// AutoScaler monitors other resources that are resizeable and adjusts them according to configuration.
+type AutoScaler struct {
+	TypeMeta   `json:",inline"`
+	ObjectMeta `json:"metadata,omitempty"`
+
+	// Spec defines the auto-scaler targets and thresholds.
+	Spec AutoScalerSpec `json:"spec,omitempty"`
+
+	// Status defines the actions the auto-scaler has taken.
+	Status AutoScalerStatus `json:"status,omitempty"`
+}
+
+// AutoScalerStatus provides the status of an auto-scaler.
+type AutoScalerStatus struct {
+	// TODO: open for discussion on what meaningful information can be reported in the status
+	// The status may return the replica count here but we may want more information
+	// such as if the count reflects a threshold being passed.
+}
+
+// AutoScalerSpec defines the auto-scaler targets and thresholds.
+type AutoScalerSpec struct {
+	// Thresholds holds a collection of AutoScaleThresholds that drive the auto-scaler.
+	Thresholds []AutoScaleThreshold `json:"thresholds,omitempty"`
+
+	// Enabled turns auto scaling on or off.
+	Enabled bool `json:"enabled,omitempty"`
+
+	// MaxAutoScaleCount defines the max replicas that the auto-scaler can use.  This value must be
+	// >= MinAutoScaleCount.
+	MaxAutoScaleCount int `json:"maxAutoScaleCount,omitempty"`
+
+	// MinAutoScaleCount defines the minimum number replicas that the auto-scaler can reduce to,
+	// 0 means that the application is allowed to idle.
+	MinAutoScaleCount int `json:"minAutoScaleCount,omitempty"`
+
+	// TargetSelector provides the resizeable target(s).  Right now this is a ReplicationController
+	// in the future it could be a job or any resource that implements resize.  If multiple targets
+	// are resolved by the selector the auto-scaler will resize the largest one.
+	TargetSelector map[string]string `json:"targetSelector,omitempty"`
+
+	// MonitorSelector defines a set of capacity that the auto-scaler is monitoring
+	// (replication controllers).  Monitored objects are used by thresholds to examine
+	// statistics.  Example: get statistic X for object Y to see if threshold is passed.
+	MonitorSelector map[string]string `json:"monitorSelector,omitempty"`
+}
+
+// AutoScaleThreshold is a behavior based on statistics used to drive the auto-scaler in scaling decisions.
+type AutoScaleThreshold struct {
+	// Type is the type of threshold being used, intention or value.
+	Type AutoScaleThresholdType `json:"type,omitempty"`
+
+	// IntentionConfig holds the config for intention based thresholds.
+	IntentionConfig AutoScaleIntentionThresholdConfig `json:"intentionConfig,omitempty"`
+}
+
+// AutoScaleIntentionThresholdConfig holds configuration for intention based thresholds.
+// The scaler will adjust by 1 accordingly and maintain once the intention is reached.
+type AutoScaleIntentionThresholdConfig struct {
+	// Intent is the lexicon of what intention is requested.
+	Intent AutoScaleIntentionType `json:"intent,omitempty"`
+
+	// Value is intention dependent in terms of above, below, equal and represents
+	// the value to check against.
+	Value float32 `json:"value,omitempty"`
+}
+
+// AutoScaleThresholdType is either intention based or value based.
+type AutoScaleThresholdType string
+
+// AutoScaleIntentionType is a lexicon for intentions such as "cpu-utilization",
+// "max-rps-per-endpoint".
+type AutoScaleIntentionType string
+
+// Constants for auto-scalers and any auto-scaling child types like intentions
+const (
+	// AutoScaleThresholdTypeIntention is used when defining an intention based threshold.
+	AutoScaleThresholdTypeIntention AutoScaleThresholdType = "Intention"
+
+	// TODO: AutoScaleIntentionType types
+	// example: AutoScaleIntentionTypeMaxRPS AutoScaleIntentionType = "MaxRPS"
+)
+
+// AutoScalerList is a list of AutoScaler items
+type AutoScalerList struct {
+	TypeMeta `json:",inline"`
+	ListMeta `json:"metadata,omitempty"`
+
+	// Items is a list of AutoScaler objects.
+	Items []AutoScaler `json:"items"`
+}

--- a/pkg/api/validation/validation.go
+++ b/pkg/api/validation/validation.go
@@ -993,3 +993,87 @@ func ValidateNamespaceUpdate(oldNamespace *api.Namespace, namespace *api.Namespa
 	}
 	return allErrs
 }
+
+// ValidateAutoScalerName can be used to check whether the given namespace name is valid.
+// Prefix indicates this name will be used as part of generation, in which case
+// trailing dashes are allowed.
+func ValidateAutoScalerName(name string, prefix bool) (bool, string) {
+	return nameIsDNSSubdomain(name, prefix)
+}
+
+// ValidateAutoScaler tests if required fields are set.
+func ValidateAutoScaler(autoScaler *api.AutoScaler) errs.ValidationErrorList {
+	allErrs := errs.ValidationErrorList{}
+	allErrs = append(allErrs, ValidateObjectMeta(&autoScaler.ObjectMeta, true, ValidateAutoScalerName).Prefix("metadata")...)
+	allErrs = append(allErrs, ValidateAutoScalerSpec(&autoScaler.Spec)...)
+	return allErrs
+}
+
+// ValidateAutoScalerSpec tests is AutoScaler.Spec required fields are set
+func ValidateAutoScalerSpec(spec *api.AutoScalerSpec) errs.ValidationErrorList {
+	allErrs := errs.ValidationErrorList{}
+
+	//must have a target selector
+	if len(spec.TargetSelector) == 0 {
+		allErrs = append(allErrs, errs.NewFieldRequired("targetSelector", spec.TargetSelector))
+	}
+
+	//min can't be greater than max
+	if spec.MinAutoScaleCount > spec.MaxAutoScaleCount {
+		allErrs = append(allErrs, errs.NewFieldInvalid("minAutoScaleCount", spec.MinAutoScaleCount, "minAutoScaleCount cannot be greater than maxAutoScaleCount"))
+	}
+
+	//must have a monitor selector
+	if len(spec.MonitorSelector) == 0 {
+		allErrs = append(allErrs, errs.NewFieldRequired("monitorSelector", spec.MonitorSelector))
+	}
+
+	//check all thresholds
+	for _, t := range spec.Thresholds {
+		allErrs = append(allErrs, ValidateAutoScaleThreshold(&t).Prefix("thresholds")...)
+	}
+
+	return allErrs
+}
+
+// ValidateAutoScaleThreshold ensures required fields are set
+func ValidateAutoScaleThreshold(t *api.AutoScaleThreshold) errs.ValidationErrorList {
+	allErrs := errs.ValidationErrorList{}
+
+	switch t.Type {
+	case api.AutoScaleThresholdTypeIntention:
+		allErrs = append(allErrs, validateIntentionThreshold(t).Prefix("intentionConfig")...)
+	default:
+		if len(t.Type) == 0 {
+			allErrs = append(allErrs, errs.NewFieldRequired("type", t.Type))
+		} else {
+			allErrs = append(allErrs, errs.NewFieldInvalid("type", t.Type, "invalid threshold type"))
+		}
+	}
+
+	return allErrs
+}
+
+// validateIntentionThreshold ensures required fields for intention based thresholds are set
+func validateIntentionThreshold(t *api.AutoScaleThreshold) errs.ValidationErrorList {
+	allErrs := errs.ValidationErrorList{}
+
+	if len(t.IntentionConfig.Intent) == 0 {
+		allErrs = append(allErrs, errs.NewFieldRequired("intent", t.IntentionConfig.Intent))
+	}
+
+	//TODO validate value of intent
+
+	return allErrs
+}
+
+// ValidateNamespaceUpdate tests to make sure a mamespace update can be applied.  Modifies oldAutoScaler.
+func ValidateAutoScalerUpdate(oldAutoScaler *api.AutoScaler, autoScaler *api.AutoScaler) errs.ValidationErrorList {
+	allErrs := errs.ValidationErrorList{}
+	allErrs = append(allErrs, ValidateObjectMetaUpdate(&oldAutoScaler.ObjectMeta, &autoScaler.ObjectMeta).Prefix("metadata")...)
+
+	//use all creation validations
+	allErrs = append(allErrs, ValidateAutoScaler(autoScaler)...)
+
+	return allErrs
+}

--- a/pkg/api/validation/validation_test.go
+++ b/pkg/api/validation/validation_test.go
@@ -2630,3 +2630,72 @@ func TestValidateSecret(t *testing.T) {
 		}
 	}
 }
+
+// TestValidateAutoScaler tests validation methods for autoscalers, their spec, and thresholds
+func TestValidateAutoScaler(t *testing.T) {
+	validAutoScaler := func() *api.AutoScaler {
+		return &api.AutoScaler{
+			ObjectMeta: api.ObjectMeta{
+				Name:      "foo",
+				Namespace: "bar",
+			},
+			Spec: api.AutoScalerSpec{
+				TargetSelector:  map[string]string{"name": "test"},
+				MonitorSelector: map[string]string{"name": "test"},
+			},
+		}
+	}
+
+	var (
+		noMetaName             = validAutoScaler()
+		noMetaNamespace        = validAutoScaler()
+		noTargetSelector       = validAutoScaler()
+		badMinMax              = validAutoScaler()
+		noMonitorSelector      = validAutoScaler()
+		invalidIntentThreshold = validAutoScaler()
+		validIntentThreshold   = validAutoScaler()
+	)
+
+	noMetaName.ObjectMeta.Name = ""
+	noMetaNamespace.ObjectMeta.Namespace = ""
+	noTargetSelector.Spec.TargetSelector = make(map[string]string, 0)
+	badMinMax.Spec.MinAutoScaleCount = 1
+	badMinMax.Spec.MaxAutoScaleCount = 0
+	noMonitorSelector.Spec.MonitorSelector = make(map[string]string, 0)
+	invalidIntentThreshold.Spec.Thresholds = []api.AutoScaleThreshold{
+		{
+			Type:            api.AutoScaleThresholdTypeIntention,
+			IntentionConfig: api.AutoScaleIntentionThresholdConfig{},
+		},
+	}
+	validIntentThreshold.Spec.Thresholds = []api.AutoScaleThreshold{
+		{
+			Type: api.AutoScaleThresholdTypeIntention,
+			IntentionConfig: api.AutoScaleIntentionThresholdConfig{
+				Intent: "test",
+			},
+		},
+	}
+
+	tests := map[string]struct {
+		errors     int
+		autoScaler *api.AutoScaler
+	}{
+		"valid":                  {0, validAutoScaler()},
+		"noMetaName":             {1, noMetaName},
+		"noMetaNamespace":        {1, noMetaNamespace},
+		"noTargetSelector":       {1, noTargetSelector},
+		"badMinMax":              {1, badMinMax},
+		"noMonitorSelector":      {1, noMonitorSelector},
+		"invalidIntentThreshold": {1, invalidIntentThreshold},
+		"validIntentThreshold":   {0, validIntentThreshold},
+	}
+
+	for testName, test := range tests {
+		result := ValidateAutoScaler(test.autoScaler)
+
+		if test.errors != len(result) {
+			t.Errorf("%s failed, expected %d errors but got %d : %v", testName, test.errors, len(result), result)
+		}
+	}
+}

--- a/pkg/registry/autoscaler/doc.go
+++ b/pkg/registry/autoscaler/doc.go
@@ -1,0 +1,19 @@
+/*
+Copyright 2015 Google Inc. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package autoscaler provides Registry interface and its REST
+// implementation for storing AutoScaler api objects.
+package autoscaler

--- a/pkg/registry/autoscaler/registry.go
+++ b/pkg/registry/autoscaler/registry.go
@@ -1,0 +1,48 @@
+/*
+Copyright 2015 Google Inc. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package autoscaler
+
+import (
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/api"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/registry/generic"
+	etcdgeneric "github.com/GoogleCloudPlatform/kubernetes/pkg/registry/generic/etcd"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/runtime"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/tools"
+)
+
+// registry implements custom changes to generic.Etcd.
+type registry struct {
+	*etcdgeneric.Etcd
+}
+
+// NewEtcdRegistry returns a registry which will store AutoScalers in the given helper
+func NewEtcdRegistry(h tools.EtcdHelper) generic.Registry {
+	return registry{
+		Etcd: &etcdgeneric.Etcd{
+			NewFunc:      func() runtime.Object { return &api.AutoScaler{} },
+			NewListFunc:  func() runtime.Object { return &api.AutoScalerList{} },
+			EndpointName: "autoscalers",
+			KeyRootFunc: func(ctx api.Context) string {
+				return etcdgeneric.NamespaceKeyRootFunc(ctx, "/registry/autoscalers")
+			},
+			KeyFunc: func(ctx api.Context, id string) (string, error) {
+				return etcdgeneric.NamespaceKeyFunc(ctx, "/registry/autoscalers", id)
+			},
+			Helper: h,
+		},
+	}
+}

--- a/pkg/registry/autoscaler/rest.go
+++ b/pkg/registry/autoscaler/rest.go
@@ -1,0 +1,147 @@
+/*
+Copyright 2015 Google Inc. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package autoscaler
+
+import (
+	"fmt"
+
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/api"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/api/errors"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/api/rest"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/api/validation"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/fields"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/labels"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/registry/generic"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/runtime"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/watch"
+)
+
+// REST provides the RESTStorage access patterns to work with AutoScaler objects.
+type REST struct {
+	registry generic.Registry
+}
+
+// NewREST returns a new REST. You must use a registry created by
+// NewEtcdRegistry unless you're testing.
+func NewREST(registry generic.Registry) *REST {
+	return &REST{
+		registry: registry,
+	}
+}
+
+// New returns a new AutoScaler.
+func (*REST) New() runtime.Object {
+	return &api.AutoScaler{}
+}
+
+// NewList returns a new AutoScaler.
+func (*REST) NewList() runtime.Object {
+	return &api.AutoScalerList{}
+}
+
+// List selects resources in the storage which match to the selector.
+func (rs *REST) List(ctx api.Context, label labels.Selector, field fields.Selector) (runtime.Object, error) {
+	return rs.registry.ListPredicate(ctx, &generic.SelectionPredicate{label, field, rs.getAttrs})
+}
+
+// getAttrs is passed to the predicate functions
+func (rs *REST) getAttrs(obj runtime.Object) (objLabels labels.Set, objFields fields.Set, err error) {
+	autoScaler, ok := obj.(*api.AutoScaler)
+	if !ok {
+		return nil, nil, fmt.Errorf("invalid object type")
+	}
+	return labels.Set(autoScaler.Labels), fields.Set{}, nil
+}
+
+// Get finds an AutoScaler in the storage by id and returns it.
+func (rs *REST) Get(ctx api.Context, id string) (runtime.Object, error) {
+	obj, err := rs.registry.Get(ctx, id)
+	if err != nil {
+		return nil, err
+	}
+	autoScaler, ok := obj.(*api.AutoScaler)
+	if !ok {
+		return nil, fmt.Errorf("invalid object type")
+	}
+	return autoScaler, err
+}
+
+// Delete finds an AutoScaler in the storage and deletes it.
+func (rs *REST) Delete(ctx api.Context, id string) (runtime.Object, error) {
+	obj, err := rs.registry.Get(ctx, id)
+	if err != nil {
+		return nil, err
+	}
+	_, ok := obj.(*api.AutoScaler)
+	if !ok {
+		return nil, fmt.Errorf("invalid object type")
+	}
+	return rs.registry.Delete(ctx, id)
+}
+
+// Create creates a new AutoScaler.
+func (rs *REST) Create(ctx api.Context, obj runtime.Object) (runtime.Object, error) {
+	if err := rest.BeforeCreate(rest.AutoScalers, ctx, obj); err != nil {
+		return nil, err
+	}
+
+	//should never fail here, BeforeCreate does a cast to do validation
+	autoScaler := obj.(*api.AutoScaler)
+	if err := rs.registry.CreateWithName(ctx, autoScaler.Name, autoScaler); err != nil {
+		return nil, err
+	}
+
+	return rs.registry.Get(ctx, autoScaler.Name)
+}
+
+// Update updates an AutoScaler object.
+func (rs *REST) Update(ctx api.Context, obj runtime.Object) (runtime.Object, bool, error) {
+	autoScaler, ok := obj.(*api.AutoScaler)
+	if !ok {
+		return nil, false, fmt.Errorf("invalid object type")
+	}
+
+	if !api.ValidNamespace(ctx, &autoScaler.ObjectMeta) {
+		return nil, false, errors.NewConflict("autoscaler", autoScaler.Namespace, fmt.Errorf("AutoScaler.Namespace does not match the provided context"))
+	}
+
+	oldObj, err := rs.registry.Get(ctx, autoScaler.Name)
+	if err != nil {
+		return nil, false, err
+	}
+
+	editAutoScaler := oldObj.(*api.AutoScaler)
+	if errs := validation.ValidateAutoScalerUpdate(editAutoScaler, autoScaler); len(errs) > 0 {
+		return nil, false, errors.NewInvalid("autoscaler", editAutoScaler.Name, errs)
+	}
+
+	// passed update validation (ensures immutable meta is not trying to be changed),
+	// now copy over the relevant fields that can be updated
+	editAutoScaler.Spec = autoScaler.Spec
+
+	err = rs.registry.UpdateWithName(ctx, editAutoScaler.Name, editAutoScaler)
+	if err != nil {
+		return nil, false, err
+	}
+	out, err := rs.registry.Get(ctx, editAutoScaler.Name)
+	return out, false, err
+}
+
+// Watch provides the ability to watch auto-scalers for changes
+func (rs *REST) Watch(ctx api.Context, label labels.Selector, field fields.Selector, resourceVersion string) (watch.Interface, error) {
+	return rs.registry.WatchPredicate(ctx, &generic.SelectionPredicate{label, field, rs.getAttrs}, resourceVersion)
+}

--- a/pkg/registry/autoscaler/rest_test.go
+++ b/pkg/registry/autoscaler/rest_test.go
@@ -1,0 +1,231 @@
+/*
+Copyright 2015 Google Inc. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package autoscaler
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/api"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/labels"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/fields"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/registry/registrytest"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/util"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/watch"
+)
+
+// testRegistry provides the REST implementation for unit tests
+type testRegistry struct {
+	*registrytest.GenericRegistry
+}
+
+func newTestREST() (testRegistry, *REST) {
+	reg := testRegistry{registrytest.NewGeneric(nil)}
+	return reg, NewREST(reg)
+}
+
+func newValidAutoScaler(name string) *api.AutoScaler {
+	return &api.AutoScaler{
+		ObjectMeta: api.ObjectMeta{
+			Name:      name,
+			Namespace: "default",
+		},
+		Spec: api.AutoScalerSpec{
+			TargetSelector:  map[string]string{"target": "selector"},
+			MonitorSelector: map[string]string{"monitor": "selector"},
+		},
+	}
+}
+
+func TestRESTCreate(t *testing.T) {
+	_, rest := newTestREST()
+
+	testCases := []struct {
+		name       string
+		ctx        api.Context
+		autoScaler *api.AutoScaler
+		valid      bool
+	}{
+		{
+			name:       "valid create",
+			ctx:        api.NewDefaultContext(),
+			autoScaler: newValidAutoScaler("valid"),
+			valid:      true,
+		},
+		{
+			name:       "empty context",
+			ctx:        api.NewContext(),
+			autoScaler: newValidAutoScaler("emptyContext"),
+			valid:      false,
+		},
+		{
+			name:       "non-default context",
+			ctx:        api.WithNamespace(api.NewContext(), "nondefault"),
+			autoScaler: newValidAutoScaler("nonDefault"),
+			valid:      false,
+		},
+	}
+
+	for _, tc := range testCases {
+		obj, err := rest.Create(tc.ctx, tc.autoScaler)
+
+		if tc.valid && err != nil {
+			t.Errorf("test case %s failed: expected no errors but found: %v", tc.name, err)
+			continue
+		}
+
+		if !tc.valid && err == nil {
+			t.Errorf("test case %s failed: expected errors but found none", tc.name)
+			continue
+		}
+
+		// at this point, if it is an invalid test case and it has errors we're good to go
+		// the rest of the validations are for fields
+		if !tc.valid {
+			continue
+		}
+
+		if !api.HasObjectMetaSystemFieldValues(&tc.autoScaler.ObjectMeta) {
+			t.Errorf("storage did not populate object meta field values")
+		}
+
+		if e, a := tc.autoScaler, obj; !reflect.DeepEqual(e, a) {
+			t.Errorf("diff: %s", util.ObjectDiff(e, a))
+		}
+	}
+}
+
+func TestRESTUpdate(t *testing.T) {
+	_, rest := newTestREST()
+	autoScaler := newValidAutoScaler("foo")
+	ctx := api.NewDefaultContext()
+
+	_, err := rest.Create(ctx, autoScaler)
+	if err != nil {
+		t.Fatalf("unable to create auto-scaler: %v", err)
+	}
+
+	autoScaler.Spec.TargetSelector["target"] = "updated"
+	updated, created, err := rest.Update(ctx, autoScaler)
+
+	if err != nil {
+		t.Fatalf("unable to create auto-scaler: %v", err)
+	}
+	if updated == nil {
+		t.Errorf("Expected non-nil object")
+	}
+	if created {
+		t.Errorf("expected created to be false")
+	}
+
+	updatedAutoScaler := updated.(*api.AutoScaler)
+	if updatedAutoScaler.Spec.TargetSelector["target"] != "updated" {
+		t.Errorf("expected target selector to be updated")
+	}
+}
+
+func TestRESTDelete(t *testing.T) {
+	_, rest := newTestREST()
+	autoScaler := newValidAutoScaler("foo")
+	_, err := rest.Create(api.NewDefaultContext(), autoScaler)
+	if err != nil {
+		t.Fatalf("unable to create auto-scaler: %v", err)
+	}
+
+	stat, err := rest.Delete(api.NewDefaultContext(), autoScaler.Name)
+	if err != nil {
+		t.Fatalf("unable to delete auto-scaler: %v", err)
+	}
+	if status := stat.(*api.Status); status.Status != api.StatusSuccess {
+		t.Errorf("unexepcted status: %v", status)
+	}
+}
+
+func TestRESTGet(t *testing.T) {
+	_, rest := newTestREST()
+	autoScaler := newValidAutoScaler("foo")
+	_, err := rest.Create(api.NewDefaultContext(), autoScaler)
+	if err != nil {
+		t.Fatalf("Unexpected error %v", err)
+	}
+	got, err := rest.Get(api.NewDefaultContext(), autoScaler.Name)
+	if err != nil {
+		t.Fatalf("Unexpected error %v", err)
+	}
+	if e, a := autoScaler, got; !reflect.DeepEqual(e, a) {
+		t.Errorf("diff: %s", util.ObjectDiff(e, a))
+	}
+}
+
+func TestRESTgetAttrs(t *testing.T) {
+	_, rest := newTestREST()
+	autoScaler := newValidAutoScaler("foo")
+	autoScaler.ObjectMeta.Labels = make(map[string]string, 1)
+	autoScaler.ObjectMeta.Labels["foo"] = "bar"
+
+	label, field, err := rest.getAttrs(autoScaler)
+	if err != nil {
+		t.Fatalf("Unexpected error %v", err)
+	}
+	if e, a := label, labels.Set(autoScaler.ObjectMeta.Labels); !reflect.DeepEqual(e, a) {
+		t.Errorf("diff: %s", util.ObjectDiff(e, a))
+	}
+	expect := fields.Set{}
+	if e, a := expect, field; !reflect.DeepEqual(e, a) {
+		t.Errorf("diff: %s", util.ObjectDiff(e, a))
+	}
+}
+
+func TestRESTList(t *testing.T) {
+	reg, rest := newTestREST()
+
+	var (
+		autoScalerA = newValidAutoScaler("a")
+		autoScalerB = newValidAutoScaler("b")
+		autoScalerC = newValidAutoScaler("c")
+	)
+
+	reg.ObjectList = &api.AutoScalerList{
+		Items: []api.AutoScaler{*autoScalerA, *autoScalerB, *autoScalerC},
+	}
+	got, err := rest.List(api.NewContext(), labels.Everything(), fields.Everything())
+	if err != nil {
+		t.Fatalf("Unexpected error %v", err)
+	}
+	expect := &api.AutoScalerList{
+		Items: []api.AutoScaler{*autoScalerA, *autoScalerB, *autoScalerC},
+	}
+	if e, a := expect, got; !reflect.DeepEqual(e, a) {
+		t.Errorf("diff: %s", util.ObjectDiff(e, a))
+	}
+}
+
+func TestRESTWatch(t *testing.T) {
+	autoScaler := newValidAutoScaler("foo")
+	reg, rest := newTestREST()
+	wi, err := rest.Watch(api.NewContext(), labels.Everything(), fields.Everything(), "0")
+	if err != nil {
+		t.Fatalf("Unexpected error %v", err)
+	}
+	go func() {
+		reg.Broadcaster.Action(watch.Added, autoScaler)
+	}()
+	got := <-wi.ResultChan()
+	if e, a := autoScaler, got.Object; !reflect.DeepEqual(e, a) {
+		t.Errorf("diff: %s", util.ObjectDiff(e, a))
+	}
+}


### PR DESCRIPTION
Pre-PR review for the auto-scaler

@smarterclayton @pmorie - my plan of attack is to submit PRs in this order to keep them small(ish):
1.  types/rest/validation (included in this PR) - starting with intention based thresholds since that seemed to be the more relevant type (vs value based)
2.  kubectl wiring - printer, wiring in master.go/client.go
3.  concrete implementations

If this generally looks good to you I'll submit the PR for real.  
